### PR TITLE
update: Add instructions for installing qemu

### DIFF
--- a/books/build_your_own_go_debugger/setup.md
+++ b/books/build_your_own_go_debugger/setup.md
@@ -17,13 +17,17 @@ Linux ホストマシンを持っている方はそちらを使用するとい�
 他の環境の場合や、最新の情報は Lima の[ドキュメント](https://lima-vm.io/docs/installation/)を参照してください。
 
 ### Lima のインストール
-まずはホストマシンに Lima をインストールします。
+まずはホストマシンに Lima をインストールします。また、Lima はデフォルトで [QEMU](https://www.qemu.org/) を使用して x86-64 アーキテクチャの仮想化を行うため、こちらもインストールします。
 
 ```shell
-brew install lima
+brew install lima qemu
 
 limactl --version
 # limactl version 0.23.2
+
+qemu-img --version
+# qemu-img version 9.1.2
+# Copyright (c) 2003-2024 Fabrice Bellard and the QEMU Project developers
 ```
 
 ### Lima のインスタンスを作成


### PR DESCRIPTION
When virtualizing the x86-64 architecture in Lima, qemu is required, so I added content related to that.
```bash
limactl create --name=go-debugger --arch=x86_64 template://ubuntu
? Creating an instance "go-debugger" Open an editor to review or modify the current configuration
INFO[0056] Attempting to download the image              arch=x86_64 digest="sha256:ee070d95a2ba5a1500264e75b3e14aa85518220c24d25f1535407c55f0e33e4d" location="https://cloud-images.ubuntu.com/releases/24.10/release-20241023/ubuntu-24.10-server-cloudimg-amd64.img"
Downloading the image (ubuntu-24.10-server-cloudimg-amd64.img)
598.80 MiB / 598.80 MiB [----------------------------------] 100.00% 12.26 MiB/s
INFO[0106] Downloaded the image from "https://cloud-images.ubuntu.com/releases/24.10/release-20241023/ubuntu-24.10-server-cloudimg-amd64.img"
FATA[0106] failed to get the information of base disk "/Users/${user-name}/.lima/go-debugger/basedisk": failed to run [qemu-img info --output=json --force-share /Users/${user-name}/.lima/go-debugger/basedisk]: stdout="", stderr="": exec: "qemu-img": executable file not found in $PATH
```

ref: https://lima-vm.io/docs/config/vmtype/